### PR TITLE
Take opentelemetry::metrics::Meter as argument

### DIFF
--- a/examples/metrics.rs
+++ b/examples/metrics.rs
@@ -1,5 +1,5 @@
 use opentelemetry::{
-    global::set_meter_provider,
+    global::{meter, set_meter_provider},
     runtime::Tokio,
     sdk::{
         export::metrics::aggregation::stateless_temporality_selector,
@@ -28,7 +28,7 @@ pub async fn main() {
     set_up_collector();
 
     trillium_tokio::run_async((
-        Metrics::new("example-app").with_route(|conn| conn.route().map(|r| r.to_string())),
+        Metrics::new(&meter("example-app")).with_route(|conn| conn.route().map(|r| r.to_string())),
         router().get("/some/:path", "ok"),
     ))
     .await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,7 @@
 )]
 
 use opentelemetry::{
-    global,
-    metrics::{Histogram, Unit},
+    metrics::{Histogram, Meter, Unit},
     Context, KeyValue,
 };
 use std::{
@@ -54,14 +53,13 @@ impl Debug for Metrics {
 }
 
 /// constructs a [`Metrics`] handler. alias for [`Metrics::new`]
-pub fn metrics(meter: &'static str) -> Metrics {
+pub fn metrics(meter: &Meter) -> Metrics {
     Metrics::new(meter)
 }
 
 impl Metrics {
     /// Constructs a new [`Metrics`] handler
-    pub fn new(meter: &'static str) -> Self {
-        let meter = global::meter(meter);
+    pub fn new(meter: &Meter) -> Self {
         Self {
             route: None,
             port: None,
@@ -92,7 +90,8 @@ impl Metrics {
     /// for use with [`trillium-router`](https://docs.trillium.rs/trillium_router/index.html),
     /// ```
     /// use trillium_router::RouterConnExt;
-    /// trillium_opentelemetry::Metrics::new("example").with_route(|conn| conn.route().map(|r| r.to_string()));
+    /// trillium_opentelemetry::Metrics::new(&opentelemetry::global::meter("example"))
+    ///     .with_route(|conn| conn.route().map(|r| r.to_string()));
     /// ```
     pub fn with_route<F>(mut self, route: F) -> Self
     where


### PR DESCRIPTION
This PR makes a breaking change to take in a reference to a `Meter`, instead of constructing one using the global meter provider and a library name. In addition to avoiding relying on a global variable, this also allows setting the version and schema URL metadata on the meter.