### PR TITLE
Update to opentelemetry-rust 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trillium-opentelemetry"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2021"
 description = "opentelemetry for trillium.rs"
@@ -16,16 +16,16 @@ metrics = ["opentelemetry/metrics"]
 trace = ["opentelemetry/trace"]
 
 [dependencies]
-opentelemetry = { version = "0.21.0", default-features = false }
+opentelemetry = { version = "0.22.0", default-features = false }
 trillium = "0.2.11"
 trillium-macros = "0.0.5"
 
 [dev-dependencies]
-opentelemetry-otlp = {version = "0.14.0", features = ["metrics", "tokio", "trace"] }
-opentelemetry =  "0.21.0"
-tokio = "1.35.0"
+opentelemetry-otlp = { version = "0.15.0", features = ["metrics", "tokio", "trace"] }
+opentelemetry =  "0.22.0"
+tokio = { version = "1.35.0", features = ["full"] }
 trillium-router = "0.3.5"
 trillium-tokio = "0.3.2"
 trillium-opentelemetry = { path = ".", features = ["metrics", "trace"] }
-opentelemetry_sdk = { version = "0.21.1", features = ["rt-tokio"] }
+opentelemetry_sdk = { version = "0.22.0", features = ["rt-tokio"] }
 env_logger = "0.11.1"


### PR DESCRIPTION
This updates to the latest opentelemetry release, and bumps the version.