### PR TITLE
Make opt-in attributes optional

### DIFF
--- a/src/instrument.rs
+++ b/src/instrument.rs
@@ -66,6 +66,26 @@ impl Instrument {
         self
     }
 
+    /// Provides a callback for `server.address` and `server.port` attributes to be used in metrics
+    /// attributes. This has no effect on tracing span attributes, where `server.address` and
+    /// `server.port` are always enabled.
+    ///
+    /// These should be set based on request headers according to the [OpenTelemetry HTTP semantic
+    /// conventions][semconv-server-address-port].
+    ///
+    /// It is not recommended to enable this when the server is exposed to clients outside of your
+    /// control, as request headers could arbitrarily increase the cardinality of these attributes.
+    ///
+    /// [semconv-server-address-port]:
+    ///     https://opentelemetry.io/docs/specs/semconv/http/http-spans/#setting-serveraddress-and-serverport-attributes
+    pub fn with_metrics_server_address_and_port<F>(mut self, server_address_and_port: F) -> Self
+    where
+        F: Fn(&Conn) -> Option<(Cow<'static, str>, u16)> + Send + Sync + 'static,
+    {
+        self.0 .1.server_address_and_port = Some(Arc::new(server_address_and_port));
+        self
+    }
+
     /// Specify a list of request headers to include in the trace spans
     pub fn with_headers(
         mut self,

--- a/src/instrument.rs
+++ b/src/instrument.rs
@@ -94,6 +94,14 @@ impl Instrument {
         self.0 .0.headers = headers.into_iter().map(Into::into).collect();
         self
     }
+
+    /// Enable population of the local socket address and port in the trace spans.
+    ///
+    /// This populates the `network.local.address` and `network.local.port` attributes.
+    pub fn with_local_address_and_port(mut self) -> Self {
+        self.0 .0.enable_local_address_and_port = true;
+        self
+    }
 }
 
 /// The primary entrypoint if using [`opentelemetry::global`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,13 +40,13 @@ pub mod global {
     pub use super::instrument_handler::instrument_handler_global as instrument_handler;
 
     #[cfg(feature = "trace")]
-    ///configure a [`Trace`] against the global tracer provider
+    ///configure a [`Trace`](crate::trace::Trace) against the global tracer provider
     pub fn trace() -> super::Trace<opentelemetry::global::BoxedTracer> {
         super::Trace::new(opentelemetry::global::tracer("trillium-opentelemetry"))
     }
 
     #[cfg(feature = "metrics")]
-    /// configure a [`Metrics`] against the global meter provider
+    /// configure a [`Metrics`](crate::metrics::Metrics) against the global meter provider
     pub fn metrics() -> super::Metrics {
         use opentelemetry::metrics::MeterProvider;
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -64,7 +64,7 @@ impl<T: Tracer> Trace<T> {
         }
     }
 
-    /// provides a route specification to the metrics collector.
+    /// provides a route specification to include in the trace spans.
     ///
     /// in order to avoid forcing anyone to use a particular router, this is provided as a
     /// configuration hook.
@@ -83,7 +83,7 @@ impl<T: Tracer> Trace<T> {
         self
     }
 
-    /// Provides an optional low-cardinality error type specification to the metrics collector.
+    /// Provides an optional low-cardinality error type specification to include in the trace spans.
     ///
     /// The implementation of this is application specific, but will often look like checking the
     /// [`Conn::state`] for an error enum and mapping that to a low-cardinality `&'static str`.


### PR DESCRIPTION
This makes the `server.address` and `server.port` metric attributes optional, allowing the user to provide them via a callback, and makes the `network.local.address` and `network.local.port` tracing span attributes optional, adding an enable/disable state. These attributes have a requirement level of "Opt-In" in their respective semantic conventions definitions. Note that `server.address` as a span attribute is recommended, and `server.port` as a span attribute is conditionally required, so I left those as-is.

I also fixed a couple small documentation issues I noticed along the way.

Closes #61.