### PR TITLE
Unset schema_url in Meter

### DIFF
--- a/src/instrument.rs
+++ b/src/instrument.rs
@@ -84,7 +84,7 @@ pub fn instrument_global() -> Instrument {
         opentelemetry::global::meter_provider().versioned_meter(
             "trillium-opentelemetry",
             Some(env!("CARGO_PKG_VERSION")),
-            Some("https://opentelemetry.io/docs/specs/semconv/"),
+            None::<&'static str>,
             None,
         ),
         opentelemetry::global::tracer("trillium-opentelemetry"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub mod global {
             .versioned_meter(
                 "trillium-opentelemetry",
                 Some(env!("CARGO_PKG_VERSION")),
-                Some("https://opentelemetry.io/docs/specs/semconv/"),
+                None::<&'static str>,
                 None,
             )
             .into()


### PR DESCRIPTION
The schema_url field in a `Meter` should be of the form `https://opentelemetry.io/schemas/1.x.y`. The schema version may be used by schema-aware collectors to rewrite various attributes, i.e. renaming attributes, renaming metrics, or splitting metrics. It's not immediately clear how one would map from a semconv version number to a schema version number, or even whether schema-aware processing is widely deployed. Thus, I think it would make sense to unset the schema_url field for now.