### PR TITLE
Upgrade to opentelemetry-rust 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,16 @@ trace = ["opentelemetry/trace"]
 
 [dependencies]
 trillium = "0.2.11"
-opentelemetry = { version = "0.23.0", default-features = false }
+opentelemetry = { version = "0.24.0", default-features = false }
+opentelemetry-semantic-conventions = "0.16.0"
 trillium-macros = "0.0.6"
 
 [dev-dependencies]
-opentelemetry-otlp = { version = "0.16.0", features = ["metrics", "tokio", "trace"] }
-opentelemetry =  "0.23.0"
+opentelemetry-otlp = { version = "0.17.0", features = ["metrics", "tokio", "trace"] }
+opentelemetry =  "0.24.0"
 tokio = { version = "1.37.0", features = ["full"] }
 trillium-router = "0.4.1"
 trillium-tokio = "0.4.0"
 trillium-opentelemetry = { path = ".", features = ["metrics", "trace"] }
-opentelemetry_sdk = { version = "0.23.0", features = ["rt-tokio"] }
+opentelemetry_sdk = { version = "0.24.0", features = ["rt-tokio"] }
 env_logger = "0.11.3"

--- a/examples/with_global.rs
+++ b/examples/with_global.rs
@@ -3,7 +3,7 @@ use opentelemetry::{
     KeyValue,
 };
 use opentelemetry_otlp::{new_exporter, new_pipeline};
-use opentelemetry_sdk::{runtime::Tokio, trace::config, Resource};
+use opentelemetry_sdk::{runtime::Tokio, trace::Config, Resource};
 use trillium::{KnownHeaderName, Status};
 use trillium_opentelemetry::global::{instrument, instrument_handler};
 use trillium_router::{router, RouterConnExt};
@@ -22,14 +22,14 @@ pub async fn main() {
     set_tracer_provider(
         new_pipeline()
             .tracing()
-            .with_trace_config(config().with_resource(Resource::new(vec![KeyValue::new(
-                "service.name",
-                "trillium-opentelemetry/examples/with_global",
-            )])))
+            .with_trace_config(
+                Config::default().with_resource(Resource::new(vec![KeyValue::new(
+                    "service.name",
+                    "trillium-opentelemetry/examples/with_global",
+                )])),
+            )
             .with_exporter(new_exporter().tonic())
             .install_batch(Tokio)
-            .unwrap()
-            .provider()
             .unwrap(),
     );
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,6 @@
 use opentelemetry::{
     global,
-    metrics::{Histogram, Meter, Unit},
+    metrics::{Histogram, Meter},
     KeyValue,
 };
 use std::{
@@ -79,19 +79,19 @@ impl From<&Meter> for Metrics {
             duration_histogram: meter
                 .f64_histogram("http.server.request.duration")
                 .with_description("Measures the duration of inbound HTTP requests.")
-                .with_unit(Unit::new("s"))
+                .with_unit("s")
                 .init(),
 
             request_size_histogram: meter
                 .u64_histogram("http.server.request.body.size")
                 .with_description("Measures the size of HTTP request messages (compressed).")
-                .with_unit(Unit::new("By"))
+                .with_unit("By")
                 .init(),
 
             response_size_histogram: meter
                 .u64_histogram("http.server.response.body.size")
                 .with_description("Measures the size of HTTP response messages (compressed).")
-                .with_unit(Unit::new("By"))
+                .with_unit("By")
                 .init(),
             error_type: None,
             server_address_and_port: None,


### PR DESCRIPTION
This upgrades crates from the opentelemetry-rust project, fixes some issues introduced by breaking changes, and replaces some string constants with new constants from `opentelemetry-semantic-conventions`, which now supports metrics as well.