### PR TITLE
Upgrade to opentelemetry-rust 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,16 @@ trace = ["opentelemetry/trace"]
 
 [dependencies]
 trillium = "0.2.11"
-opentelemetry = { version = "0.24.0", default-features = false }
-opentelemetry-semantic-conventions = "0.16.0"
+opentelemetry = { version = "0.27.1", default-features = false }
+opentelemetry-semantic-conventions = { version = "0.27.0", features = ["semconv_experimental"] }
 trillium-macros = "0.0.6"
 
 [dev-dependencies]
-opentelemetry-otlp = { version = "0.17.0", features = ["metrics", "tokio", "trace"] }
-opentelemetry =  "0.24.0"
+opentelemetry-otlp = { version = "0.27.0", features = ["metrics", "tokio", "trace"] }
+opentelemetry = "0.27.1"
 tokio = { version = "1.37.0", features = ["full"] }
 trillium-router = "0.4.1"
 trillium-tokio = "0.4.0"
 trillium-opentelemetry = { path = ".", features = ["metrics", "trace"] }
-opentelemetry_sdk = { version = "0.24.0", features = ["rt-tokio"] }
+opentelemetry_sdk = { version = "0.27.1", features = ["rt-tokio"] }
 env_logger = "0.11.3"

--- a/examples/metrics.rs
+++ b/examples/metrics.rs
@@ -1,17 +1,17 @@
 use opentelemetry::global::set_meter_provider;
-use opentelemetry_otlp::{new_exporter, new_pipeline};
-use opentelemetry_sdk::runtime::Tokio;
+use opentelemetry_otlp::MetricExporter;
+use opentelemetry_sdk::{
+    metrics::{PeriodicReader, SdkMeterProvider},
+    runtime::Tokio,
+};
 use trillium_opentelemetry::Metrics;
 use trillium_router::{router, RouterConnExt};
 
 fn set_up_collector() {
-    set_meter_provider(
-        new_pipeline()
-            .metrics(Tokio)
-            .with_exporter(new_exporter().tonic())
-            .build()
-            .unwrap(),
-    );
+    let exporter = MetricExporter::builder().with_tonic().build().unwrap();
+    let reader = PeriodicReader::builder(exporter, Tokio).build();
+    let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
+    set_meter_provider(meter_provider);
 }
 
 #[tokio::main]

--- a/src/instrument.rs
+++ b/src/instrument.rs
@@ -1,7 +1,7 @@
 use crate::{Metrics, Trace};
 use opentelemetry::{
     global::{BoxedTracer, ObjectSafeTracer},
-    metrics::MeterProvider,
+    InstrumentationScope,
 };
 use std::{borrow::Cow, sync::Arc};
 use trillium::{Conn, HeaderName};
@@ -109,11 +109,11 @@ impl Instrument {
 /// constructs a versioned meter and tracer with the name `"trillium-opentelemetry"`.
 pub fn instrument_global() -> Instrument {
     instrument(
-        opentelemetry::global::meter_provider().versioned_meter(
-            "trillium-opentelemetry",
-            Some(env!("CARGO_PKG_VERSION")),
-            Some("https://opentelemetry.io/schemas/1.22.0"),
-            None,
+        opentelemetry::global::meter_provider().meter_with_scope(
+            InstrumentationScope::builder("trillium-opentelemetry")
+                .with_version(env!("CARGO_PKG_VERSION"))
+                .with_schema_url("https://opentelemetry.io/schemas/1.29.0")
+                .build(),
         ),
         opentelemetry::global::tracer("trillium-opentelemetry"),
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,14 +48,14 @@ pub mod global {
     #[cfg(feature = "metrics")]
     /// configure a [`Metrics`](crate::metrics::Metrics) against the global meter provider
     pub fn metrics() -> super::Metrics {
-        use opentelemetry::metrics::MeterProvider;
+        use opentelemetry::InstrumentationScope;
 
         opentelemetry::global::meter_provider()
-            .versioned_meter(
-                "trillium-opentelemetry",
-                Some(env!("CARGO_PKG_VERSION")),
-                Some("https://opentelemetry.io/schemas/1.22.0"),
-                None,
+            .meter_with_scope(
+                InstrumentationScope::builder("trillium-opentelemetry")
+                    .with_version(env!("CARGO_PKG_VERSION"))
+                    .with_schema_url("https://opentelemetry.io/schemas/1.29.0")
+                    .build(),
             )
             .into()
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -81,19 +81,19 @@ impl From<&Meter> for Metrics {
                 .f64_histogram(semconv::metric::HTTP_SERVER_REQUEST_DURATION)
                 .with_description("Measures the duration of inbound HTTP requests.")
                 .with_unit("s")
-                .init(),
+                .build(),
 
             request_size_histogram: meter
                 .u64_histogram(semconv::metric::HTTP_SERVER_REQUEST_BODY_SIZE)
                 .with_description("Measures the size of HTTP request messages (compressed).")
                 .with_unit("By")
-                .init(),
+                .build(),
 
             response_size_histogram: meter
                 .u64_histogram(semconv::metric::HTTP_SERVER_RESPONSE_BODY_SIZE)
                 .with_description("Measures the size of HTTP response messages (compressed).")
                 .with_unit("By")
-                .init(),
+                .build(),
             error_type: None,
             server_address_and_port: None,
         }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -243,7 +243,7 @@ where
                 }
             });
 
-        if conn.status().map_or(false, |s| s.is_server_error()) {
+        if conn.status().is_some_and(|s| s.is_server_error()) {
             span.set_status(opentelemetry::trace::Status::Error {
                 description: "".into(), // see error.type
             });


### PR DESCRIPTION
This upgrades all opentelemetry-rust crates to the 0.27 release. (I'm skipping a couple versions because the 0.25 and 0.26 releases temporarily removed Prometheus exporter support) I updated the schema URL to reflect that opentelemetry-semantic-conventions 0.27.0 is based on version 1.29.0 of the semantic conventions, and confirmed that none of the spans, metrics, or attributes we use were affected by any intervening changes. Note that newer versions of opentelemetry-semantic-conventions put items behind a "semconv_experimental" feature flag if they represent something with "experimental" stability in the specification. This affects both the `http.server.request.body.size` and `http.server.response.body.size` metrics.

I also fixed a Clippy lint introduced by yesterday's 1.84 toolchain release.

This replaces #87, #90, #91, and #92.