### PR TITLE
Histogram boundary configuration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub use instrument::{instrument, Instrument};
 #[cfg(feature = "trace")]
 pub use instrument_handler::{instrument_handler, InstrumentHandler};
 #[cfg(feature = "metrics")]
-pub use metrics::{metrics, Metrics};
+pub use metrics::{metrics, Metrics, MetricsBuilder};
 #[cfg(feature = "trace")]
 pub use trace::{trace, Trace};
 


### PR DESCRIPTION
This introduces a separate builder struct, and then adds configuration methods to the builder to set the boundaries of each histogram. See also https://github.com/trillium-rs/trillium-opentelemetry/pull/93#issuecomment-2587934722.