### PR TITLE
Upgrade to opentelemetry-rust 0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,16 @@ trace = ["opentelemetry/trace"]
 
 [dependencies]
 trillium = "0.2.11"
-opentelemetry = { version = "0.27.1", default-features = false }
-opentelemetry-semantic-conventions = { version = "0.27.0", features = ["semconv_experimental"] }
+opentelemetry = { version = "0.28.0", default-features = false }
+opentelemetry-semantic-conventions = { version = "0.28.0", features = ["semconv_experimental"] }
 trillium-macros = "0.0.6"
 
 [dev-dependencies]
-opentelemetry-otlp = { version = "0.27.0", features = ["metrics", "tokio", "trace"] }
-opentelemetry = "0.27.1"
+opentelemetry-otlp = { version = "0.28.0", features = ["metrics", "tokio", "trace"] }
+opentelemetry = "0.28.0"
 tokio = { version = "1.37.0", features = ["full"] }
 trillium-router = "0.4.1"
 trillium-tokio = "0.4.0"
 trillium-opentelemetry = { path = ".", features = ["metrics", "trace"] }
-opentelemetry_sdk = { version = "0.27.1", features = ["rt-tokio"] }
+opentelemetry_sdk = "0.28.0"
 env_logger = "0.11.3"

--- a/examples/metrics.rs
+++ b/examples/metrics.rs
@@ -1,15 +1,12 @@
 use opentelemetry::global::set_meter_provider;
 use opentelemetry_otlp::MetricExporter;
-use opentelemetry_sdk::{
-    metrics::{PeriodicReader, SdkMeterProvider},
-    runtime::Tokio,
-};
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use trillium_opentelemetry::Metrics;
 use trillium_router::{router, RouterConnExt};
 
 fn set_up_collector() {
-    let exporter = MetricExporter::builder().with_tonic().build().unwrap();
-    let reader = PeriodicReader::builder(exporter, Tokio).build();
+    let exporter = MetricExporter::builder().with_http().build().unwrap();
+    let reader = PeriodicReader::builder(exporter).build();
     let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
     set_meter_provider(meter_provider);
 }

--- a/src/instrument.rs
+++ b/src/instrument.rs
@@ -1,8 +1,5 @@
-use crate::{Metrics, Trace};
-use opentelemetry::{
-    global::{BoxedTracer, ObjectSafeTracer},
-    InstrumentationScope,
-};
+use crate::{instrumentation_scope, Metrics, Trace};
+use opentelemetry::global::{BoxedTracer, ObjectSafeTracer};
 use std::{borrow::Cow, sync::Arc};
 use trillium::{Conn, HeaderName};
 use trillium_macros::Handler;
@@ -108,13 +105,9 @@ impl Instrument {
 ///
 /// constructs a versioned meter and tracer with the name `"trillium-opentelemetry"`.
 pub fn instrument_global() -> Instrument {
+    let scope = instrumentation_scope();
     instrument(
-        opentelemetry::global::meter_provider().meter_with_scope(
-            InstrumentationScope::builder("trillium-opentelemetry")
-                .with_version(env!("CARGO_PKG_VERSION"))
-                .with_schema_url("https://opentelemetry.io/schemas/1.29.0")
-                .build(),
-        ),
-        opentelemetry::global::tracer("trillium-opentelemetry"),
+        opentelemetry::global::meter_provider().meter_with_scope(scope.clone()),
+        opentelemetry::global::tracer_with_scope(scope),
     )
 }

--- a/src/instrument_handler.rs
+++ b/src/instrument_handler.rs
@@ -1,4 +1,4 @@
-use crate::trace::TraceContext;
+use crate::{instrumentation_scope, trace::TraceContext};
 use opentelemetry::{
     global::BoxedTracer,
     trace::{FutureExt, TraceContextExt, Tracer},
@@ -139,6 +139,6 @@ where
 {
     InstrumentHandler::new(
         handler,
-        opentelemetry::global::tracer("trillium-opentelemetry"),
+        opentelemetry::global::tracer_with_scope(instrumentation_scope()),
     )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ pub use instrument_handler::{instrument_handler, InstrumentHandler};
 pub use metrics::{metrics, Metrics};
 #[cfg(any(feature = "trace", feature = "metrics"))]
 use opentelemetry::InstrumentationScope;
+#[cfg(any(feature = "trace", feature = "metrics"))]
+use opentelemetry_semantic_conventions::SCHEMA_URL;
 #[cfg(feature = "trace")]
 pub use trace::{trace, Trace};
 
@@ -64,6 +66,6 @@ pub mod global {
 fn instrumentation_scope() -> InstrumentationScope {
     InstrumentationScope::builder("trillium-opentelemetry")
         .with_version(env!("CARGO_PKG_VERSION"))
-        .with_schema_url("https://opentelemetry.io/schemas/1.29.0")
+        .with_schema_url(SCHEMA_URL)
         .build()
 }


### PR DESCRIPTION
This upgrades to opentelemetry-rust 0.28, which is hot off the presses. This upgrade only required changes to the examples to address the change in default exporter protocol, the exporter no longer using an async runtime by default, and new APIs for constructing a `Resource`. I also refactored instrumentation scope construction in initialization functions that use global providers, and updated the schema URL. I confirmed there are no semantic conventions changes relevant to this library.